### PR TITLE
This fixes a memory leak in LoadImage()

### DIFF
--- a/RprLoadStore/frs6.cpp
+++ b/RprLoadStore/frs6.cpp
@@ -1196,6 +1196,7 @@ rpr_image FRS6::LoadImage(rpr_context context, std::istream *myfile)
 	if (checkCode != m_IMAGE_END)
 	{
 		ErrorDetected();
+		delete[] idata;
 		return 0;
 	}
 


### PR DESCRIPTION
This fixes a memory leak in LoadImage(), where it would return on an error without deleting the image data first.