### PR TITLE
Fixing linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Tools\premake\win\premake5 vs2015
 Linux:
 
 ```
-Tools\premake\linux64\premake5 gmake
-
+chmod +x Tools/premake/linux64/premake5
+Tools/premake/linux64/premake5 gmake
 make config=release_x64
 ```
 


### PR DESCRIPTION
Two changes required

 - Linux doesn't use "\" for folders
 - premake5 needs to be made executable first