### PR TITLE
Bug fix: Don't ignore the first material in an OBJ/MTL file.

### DIFF
--- a/Baikal/SceneGraph/IO/scene_io.cpp
+++ b/Baikal/SceneGraph/IO/scene_io.cpp
@@ -216,7 +216,7 @@ namespace Baikal
             // Set material
             auto idx = objshapes[s].mesh.material_ids[0];
 
-            if (idx > 0)
+            if (idx >= 0)
             {
                 mesh->SetMaterial(materials[idx]);
             }


### PR DESCRIPTION
Simple bug fix. In the previous version the first material in an MTL file was never used.

This can be easily verified by changing the CornellBox `backWall` material in `orig.mtl`. For example, `Kd 1 0 0` shows no effect in the previous version.