### PR TITLE
Path seems wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Available premake options:
 ## Run
 
 ## Run Baikal standalone app
- - `export LD_LIBRARY_PATH=<Radeon Rays_SDK path>/Radeon Rays/lib/x64/:${LD_LIBRARY_PATH}`
+ - `export LD_LIBRARY_PATH=<RadeonProRender-Baikal path>/Bin/Release/x64/:${LD_LIBRARY_PATH}`
  - `cd Baikal`
  - `../Bin/Release/x64/Baikal64`
 


### PR DESCRIPTION
This was working for me though.
Why do I need to set this? It's in the same repository, so the standalone could just figure out the path itself?
Anyways, thanks for finally making the build happen in a transparent way!