### PR TITLE
Account for area in area light sampling.

### DIFF
--- a/Baikal/Kernels/CL/light.cl
+++ b/Baikal/Kernels/CL/light.cl
@@ -222,7 +222,7 @@ float3 AreaLight_Sample(// Emissive object
         float dist2 = dot(*wo, *wo);
         float denom = fabs(ndotv) * area;
         *pdf = denom > 0.f ? dist2 / denom : 0.f;
-        return dist2 > 0.f ? ke * ndotv / dist2 : 0.f;
+        return dist2 > 0.f ? ke * area * ndotv / dist2 : 0.f;
     }
     else
     {


### PR DESCRIPTION
Without this, ridiculously large emission values (in the millions) are needed in scenes with large scales (e.g., Sponza) to get any contribution from indirect lighting.

I believe this fix is correct based on experimental results and [this StackOverflow answer](https://computergraphics.stackexchange.com/a/4302). However, I don't have a good insight to the math involved, so feel free to reject the PR if there is a more correct way to fix the issue.

Note that this issue doesn't affect CornellBox all that much because the area of the light source is quite close to 1 (about 0.2 from what I could tell).