### PR TITLE
Environment override

### DIFF
--- a/Baikal/Controllers/clw_scene_controller.cpp
+++ b/Baikal/Controllers/clw_scene_controller.cpp
@@ -1379,6 +1379,10 @@ namespace Baikal
 
         // Disable IBL by default
         out.envmapidx = -1;
+        out.env_background_override_idx = -1;
+        out.env_reflection_override_idx = -1;
+        out.env_refraction_override_idx = -1;
+        out.env_transparency_override_idx = -1;
 
         // Allocate intermediate storage for lights power distribution
         std::vector<float> light_power(num_lights);

--- a/Baikal/Controllers/clw_scene_controller.cpp
+++ b/Baikal/Controllers/clw_scene_controller.cpp
@@ -1360,6 +1360,8 @@ namespace Baikal
     {
         std::size_t num_lights_written = 0;
         
+        auto env_override = scene.GetEnvironmentOverride();
+
         auto num_lights = scene.GetNumLights();
         auto distribution_buffer_size = (1 + 1 + num_lights + num_lights);
 
@@ -1394,7 +1396,16 @@ namespace Baikal
                 auto ibl = std::dynamic_pointer_cast<ImageBasedLight>(light_iter->ItemAs<Light>());
                 if (ibl)
                 {
-                    out.envmapidx = static_cast<int>(num_lights_written);
+                    if (ibl == env_override.m_background)
+                        out.env_background_override_idx = static_cast<int>(num_lights_written);
+                    else if(ibl == env_override.m_reflection)
+                        out.env_reflection_override_idx = static_cast<int>(num_lights_written);
+                    else if (ibl == env_override.m_refraction)
+                        out.env_refraction_override_idx = static_cast<int>(num_lights_written);
+                    else if (ibl == env_override.m_transparency)
+                        out.env_transparency_override_idx = static_cast<int>(num_lights_written);
+                    else 
+                        out.envmapidx = static_cast<int>(num_lights_written);
                 }
 
                 ++num_lights_written;
@@ -1405,6 +1416,8 @@ namespace Baikal
                 light_power[k++] = 0.2126f * power.x + 0.7152f * power.y + 0.0722f * power.z;
             }
         }
+
+
 
         m_context.UnmapBuffer(0, out.lights, lights);
 

--- a/Baikal/Controllers/clw_scene_controller.cpp
+++ b/Baikal/Controllers/clw_scene_controller.cpp
@@ -1421,8 +1421,6 @@ namespace Baikal
             }
         }
 
-
-
         m_context.UnmapBuffer(0, out.lights, lights);
 
         // Create distribution over light sources based on their power

--- a/Baikal/Controllers/scene_controller.inl
+++ b/Baikal/Controllers/scene_controller.inl
@@ -368,7 +368,7 @@ namespace Baikal
             }
 
             // If background image need an update, do it.
-            if (((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground)) 
+            if ((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground) 
             {
                 UpdateSceneAttributes(*scene, m_texture_collector, out);
             }

--- a/Baikal/Controllers/scene_controller.inl
+++ b/Baikal/Controllers/scene_controller.inl
@@ -368,7 +368,7 @@ namespace Baikal
             }
 
             // If background image need an update, do it.
-            if ((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground)
+            if (((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground)) 
             {
                 UpdateSceneAttributes(*scene, m_texture_collector, out);
             }

--- a/Baikal/Controllers/scene_controller.inl
+++ b/Baikal/Controllers/scene_controller.inl
@@ -368,7 +368,7 @@ namespace Baikal
             }
 
             // If background image need an update, do it.
-            if ((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground) 
+            if ((scene->GetDirtyFlags() & Scene1::kBackground) == Scene1::kBackground)
             {
                 UpdateSceneAttributes(*scene, m_texture_collector, out);
             }

--- a/Baikal/Estimators/path_tracing_estimator.cpp
+++ b/Baikal/Estimators/path_tracing_estimator.cpp
@@ -216,7 +216,7 @@ namespace Baikal
             // Apply scattering
             EvaluateVolume(scene, pass, num_estimates, output, use_output_indices);
 
-            if (pass > 0 && (
+            if ((pass > 0) && (
                 (scene.envmapidx > -1) || (scene.env_reflection_override_idx > -1) ||
                 (scene.env_refraction_override_idx > -1) || (scene.env_transparency_override_idx > -1)))
             {

--- a/Baikal/Estimators/path_tracing_estimator.cpp
+++ b/Baikal/Estimators/path_tracing_estimator.cpp
@@ -575,7 +575,7 @@ namespace Baikal
     )
     {
         bool use_miss_with_override = (scene.env_reflection_override_idx > -1) ||
-            (scene.env_refraction_override_idx > -1) || (scene.env_transparency_override_idx);
+            (scene.env_refraction_override_idx > -1) || (scene.env_transparency_override_idx > -1);
         auto misskernel = (use_miss_with_override) ? GetKernel("ShadeMissWithOverride") : GetKernel("ShadeMiss");
 
         auto output_indices = use_output_indices ? m_render_data->output_indices : m_render_data->iota;

--- a/Baikal/Kernels/CL/bxdf.cl
+++ b/Baikal/Kernels/CL/bxdf.cl
@@ -1192,4 +1192,19 @@ bool Bxdf_IsBtdf(DifferentialGeometry const* dg)
         dg->mat.type == kMicrofacetRefractionGGX || dg->mat.type == kMicrofacetRefractionBeckmann;
 }
 
+bool Bxdf_IsRefraction(DifferentialGeometry const* dg)
+{
+    return dg->mat.type == kIdealRefract || dg->mat.type == kMicrofacetRefractionGGX || dg->mat.type == kMicrofacetRefractionBeckmann;
+}
+
+bool Bxdf_IsReflection(DifferentialGeometry const* dg)
+{
+    return dg->mat.type == kIdealReflect;
+}
+
+bool Bxdf_IsTransparency(DifferentialGeometry const* dg)
+{
+    return dg->mat.type == kPassthrough;
+}
+
 #endif // BXDF_CL

--- a/Baikal/Kernels/CL/path.cl
+++ b/Baikal/Kernels/CL/path.cl
@@ -38,7 +38,10 @@ typedef enum _PathFlags
     kNone = 0x0,
     kKilled = 0x1,
     kScattered = 0x2,
-    kSpecularBounce = 0x4
+    kSpecularBounce = 0x4,
+    kRefraction = 0x8,
+    kTransparency = 0x10,
+    kReflectionn = 0x20
 } PathFlags;
 
 bool Path_IsScattered(__global Path const* path)
@@ -113,6 +116,48 @@ void Path_AddContribution(__global Path* path, __global float3* output, int idx,
     output[idx] += Path_GetThroughput(path) * val;
 }
 
+void Path_SetRefractionFlag(__global Path* path)
+{
+    path->flags |= kRefraction;
+}
 
+void Path_ClearRefractionFlag(__global Path* path)
+{
+    path->flags &= ~kRefraction;
+}
 
+bool Path_IsRefraction(__global Path const* path)
+{
+    return path->flags & kRefraction;
+}
+
+void Path_SetTransparencyFlag(__global Path* path)
+{
+    path->flags |= kTransparency;
+}
+
+void Path_ClearTransparencyFlag(__global Path* path)
+{
+    path->flags &= ~kTransparency;
+}
+
+bool Path_IsTransparency(__global Path const* path)
+{
+    return path->flags & kTransparency;
+}
+
+void Path_SetReflectionFlag(__global Path* path)
+{
+    path->flags |= kReflectionn;
+}
+
+void Path_ClearReflectionFlag(__global Path* path)
+{
+    path->flags &= ~kReflectionn;
+}
+
+bool Path_IsReflection(__global Path const* path)
+{
+    return path->flags & kReflectionn;
+}
 #endif

--- a/Baikal/Kernels/CL/path_tracing_estimator.cl
+++ b/Baikal/Kernels/CL/path_tracing_estimator.cl
@@ -890,15 +890,15 @@ KERNEL void ShadeMissWithOverride(
         if (isects[global_id].shapeid < 0 && Path_IsAlive(path))
         {
             int used_env_light_idx = env_light_idx;
-            if (Path_IsReflection(path))
+            if (Path_IsReflection(path) && (env_reflection_idx > -1))
             {
                 used_env_light_idx = env_reflection_idx;
             }
-            if (Path_IsRefraction(path))
+            else if (Path_IsRefraction(path) && (env_refraction_idx > -1))
             {
                 used_env_light_idx = env_refraction_idx;
             }
-            if (Path_IsTransparency(path))
+            else if (Path_IsTransparency(path) && (env_transparency_idx > -1))
             {
                 used_env_light_idx = env_transparency_idx;
             }

--- a/Baikal/SceneGraph/clwscene.h
+++ b/Baikal/SceneGraph/clwscene.h
@@ -47,6 +47,10 @@ namespace Baikal
         int num_lights;
         int envmapidx;
         int background_idx;
+        int env_reflection_override_idx;
+        int env_refraction_override_idx;
+        int env_transparency_override_idx;
+        int env_background_override_idx;
         CameraType camera_type;
 
         std::vector<RadeonRays::Shape*> isect_shapes;

--- a/Baikal/SceneGraph/scene1.cpp
+++ b/Baikal/SceneGraph/scene1.cpp
@@ -196,27 +196,21 @@ namespace Baikal
 
     void Scene1::SetEnvironmentOverride(const EnvironmentOverride& env_override)
     {
-        if (m_impl->m_environment_override.m_background != env_override.m_background)
+        auto check_and_set_light = [&](ImageBasedLight::Ptr current_light, ImageBasedLight::Ptr new_light)
         {
-            DetachLight(m_impl->m_environment_override.m_background);
-            AttachLight(env_override.m_background);
-        }
-        if (m_impl->m_environment_override.m_reflection != env_override.m_reflection)
-        {
-            DetachLight(m_impl->m_environment_override.m_reflection);
-            AttachLight(env_override.m_reflection);
-        }
-        if (m_impl->m_environment_override.m_refraction != env_override.m_refraction)
-        {
-            DetachLight(m_impl->m_environment_override.m_refraction);
-            AttachLight(env_override.m_refraction);
-        }
-        if (m_impl->m_environment_override.m_transparency != env_override.m_transparency)
-        {
-            DetachLight(m_impl->m_environment_override.m_transparency);
-            AttachLight(env_override.m_transparency);
-        }
+            if (current_light != new_light)
+            {
+                if (current_light)
+                    DetachLight(current_light);
+                if (new_light)
+                    AttachLight(new_light);
+            }
+        };
 
+        check_and_set_light(m_impl->m_environment_override.m_background, env_override.m_background);
+        check_and_set_light(m_impl->m_environment_override.m_reflection, env_override.m_reflection);
+        check_and_set_light(m_impl->m_environment_override.m_refraction, env_override.m_refraction);
+        check_and_set_light(m_impl->m_environment_override.m_transparency, env_override.m_transparency);
         m_impl->m_environment_override = env_override;
     }
     const Scene1::EnvironmentOverride& Scene1::GetEnvironmentOverride() const

--- a/Baikal/SceneGraph/scene1.cpp
+++ b/Baikal/SceneGraph/scene1.cpp
@@ -21,6 +21,7 @@ namespace Baikal
         LightList m_lights;
         Camera::Ptr m_camera;
         Baikal::Texture::Ptr m_background_texture;
+        EnvironmentOverride m_environment_override;
 
         DirtyFlags m_dirty_flags;
     };
@@ -191,6 +192,36 @@ namespace Baikal
     Baikal::Texture::Ptr Scene1::GetBackgroundImage() const
     {
         return m_impl->m_background_texture;
+    }
+
+    void Scene1::SetEnvironmentOverride(const EnvironmentOverride& env_override)
+    {
+        if (m_impl->m_environment_override.m_background != env_override.m_background)
+        {
+            DetachLight(m_impl->m_environment_override.m_background);
+            AttachLight(env_override.m_background);
+        }
+        if (m_impl->m_environment_override.m_reflection != env_override.m_reflection)
+        {
+            DetachLight(m_impl->m_environment_override.m_reflection);
+            AttachLight(env_override.m_reflection);
+        }
+        if (m_impl->m_environment_override.m_refraction != env_override.m_refraction)
+        {
+            DetachLight(m_impl->m_environment_override.m_refraction);
+            AttachLight(env_override.m_refraction);
+        }
+        if (m_impl->m_environment_override.m_transparency != env_override.m_transparency)
+        {
+            DetachLight(m_impl->m_environment_override.m_transparency);
+            AttachLight(env_override.m_transparency);
+        }
+
+        m_impl->m_environment_override = env_override;
+    }
+    const Scene1::EnvironmentOverride& Scene1::GetEnvironmentOverride() const
+    {
+        return m_impl->m_environment_override;
     }
 
     namespace {

--- a/Baikal/SceneGraph/scene1.h
+++ b/Baikal/SceneGraph/scene1.h
@@ -66,7 +66,15 @@ namespace Baikal
             kCamera,
             kBackground
         };
-        
+
+        struct EnvironmentOverride
+        {
+            ImageBasedLight::Ptr m_reflection;
+            ImageBasedLight::Ptr m_refraction;
+            ImageBasedLight::Ptr m_transparency;
+            ImageBasedLight::Ptr m_background;
+        };
+      
         // Destructor
         virtual ~Scene1();
 
@@ -111,6 +119,9 @@ namespace Baikal
         // Background image override
         void SetBackgroundImage(Baikal::Texture::Ptr texture);
         Baikal::Texture::Ptr GetBackgroundImage() const;
+
+        void SetEnvironmentOverride(const EnvironmentOverride& env_override);
+        const EnvironmentOverride& GetEnvironmentOverride() const;
         
         // Forbidden stuff
         Scene1(Scene1 const&) = delete;

--- a/Rpr/RadeonProRender.cpp
+++ b/Rpr/RadeonProRender.cpp
@@ -1940,7 +1940,7 @@ rpr_int rprSceneSetEnvironmentOverride(rpr_scene in_scene, rpr_environment_overr
     SceneObject* scene = WrapObject::Cast<SceneObject>(in_scene);
     LightObject* light = WrapObject::Cast<LightObject>(in_light);
 
-    if (!scene || !light || light->GetType() != LightObject::Type::kEnvironmentLight)
+    if (!scene)
     {
         return RPR_ERROR_INVALID_PARAMETER;
     }
@@ -1953,13 +1953,16 @@ rpr_int rprSceneSetEnvironmentOverride(rpr_scene in_scene, rpr_environment_overr
         { RPR_SCENE_ENVIRONMENT_OVERRIDE_TRANSPARENCY, SceneObject::OverrideType::kTransparency }
     };
 
-    auto overryde_type = override_type_conversion.find(overrride);
-    if (overryde_type  == override_type_conversion.end())
+    auto override_type = override_type_conversion.find(overrride);
+    if (override_type  == override_type_conversion.end())
         return RPR_ERROR_INVALID_PARAMETER;
 
     try
     {
-        scene->SetEnvironmentOverride(overryde_type->second, light);
+        if ((overrride == RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND) && light)
+            rprSceneSetBackgroundImage(scene, nullptr);
+
+        scene->SetEnvironmentOverride(override_type->second, light);
     }
     catch (Exception& e)
     {
@@ -1973,13 +1976,15 @@ rpr_int rprSceneSetBackgroundImage(rpr_scene in_scene, rpr_image in_image)
 {
     MaterialObject* img = WrapObject::Cast<MaterialObject>(in_image);
     SceneObject* scene = WrapObject::Cast<SceneObject>(in_scene);
-    if (!scene || !img || !img->IsImg())
+    if (!scene)
     {
         return RPR_ERROR_INVALID_PARAMETER;
     }
 
     try
     {
+        if (img)
+            rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND, nullptr);
         scene->SetBackgroundImage(img);
     }
     catch (Exception& e)

--- a/Rpr/RadeonProRender.cpp
+++ b/Rpr/RadeonProRender.cpp
@@ -1902,14 +1902,71 @@ rpr_int rprSceneGetInfo(rpr_scene in_scene, rpr_scene_info in_info, size_t in_si
     return RPR_SUCCESS;
 }
 
-rpr_int rprSceneGetEnvironmentOverride(rpr_scene scene, rpr_environment_override overrride, rpr_light * out_light)
+rpr_int rprSceneGetEnvironmentOverride(rpr_scene in_scene, rpr_environment_override overrride, rpr_light * out_light)
 {
-    UNSUPPORTED_FUNCTION
+    SceneObject* scene = WrapObject::Cast<SceneObject>(in_scene);
+
+    if (!scene)
+    {
+        return RPR_ERROR_INVALID_PARAMETER;
+    }
+
+    static const std::map<rpr_environment_override, SceneObject::OverrideType> override_type_conversion =
+    {
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND, SceneObject::OverrideType::kBackground },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_REFLECTION, SceneObject::OverrideType::kReflection },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_REFRACTION, SceneObject::OverrideType::kRefraction },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_TRANSPARENCY, SceneObject::OverrideType::kTransparency }
+    };
+
+    auto overryde_type = override_type_conversion.find(overrride);
+    if (overryde_type == override_type_conversion.end())
+        return RPR_ERROR_INVALID_PARAMETER;
+
+    try
+    {
+        *out_light = scene->GetEnvironmentOverride(overryde_type->second);
+    }
+    catch (Exception& e)
+    {
+        return e.m_error;
+    }
+
+    return RPR_SUCCESS;
 }
 
-rpr_int rprSceneSetEnvironmentOverride(rpr_scene scene, rpr_environment_override overrride, rpr_light light)
+rpr_int rprSceneSetEnvironmentOverride(rpr_scene in_scene, rpr_environment_override overrride, rpr_light in_light)
 {
-    UNSUPPORTED_FUNCTION
+    SceneObject* scene = WrapObject::Cast<SceneObject>(in_scene);
+    LightObject* light = WrapObject::Cast<LightObject>(in_light);
+
+    if (!scene || !light || light->GetType() != LightObject::Type::kEnvironmentLight)
+    {
+        return RPR_ERROR_INVALID_PARAMETER;
+    }
+
+    static const std::map<rpr_environment_override, SceneObject::OverrideType> override_type_conversion =
+    {
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND, SceneObject::OverrideType::kBackground },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_REFLECTION, SceneObject::OverrideType::kReflection },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_REFRACTION, SceneObject::OverrideType::kRefraction },
+        { RPR_SCENE_ENVIRONMENT_OVERRIDE_TRANSPARENCY, SceneObject::OverrideType::kTransparency }
+    };
+
+    auto overryde_type = override_type_conversion.find(overrride);
+    if (overryde_type  == override_type_conversion.end())
+        return RPR_ERROR_INVALID_PARAMETER;
+
+    try
+    {
+        scene->SetEnvironmentOverride(overryde_type->second, light);
+    }
+    catch (Exception& e)
+    {
+        return e.m_error;
+    }
+
+    return RPR_SUCCESS;
 }
 
 rpr_int rprSceneSetBackgroundImage(rpr_scene in_scene, rpr_image in_image)

--- a/Rpr/WrapObject/Materials/SingleBxdfMaterialObject.cpp
+++ b/Rpr/WrapObject/Materials/SingleBxdfMaterialObject.cpp
@@ -90,17 +90,24 @@ void SingleBxdfMaterialObject::SetInputF(const std::string& input_name, const Ra
     m_base_mat->SetInputValue(input_name, val);
 
     //if roughness is to small replace microfacet by ideal reflect
-    if (GetType() && input_name == "roughness")
+    MaterialObject::Type type = GetType();
+    if ( type && input_name == "roughness")
     {
         if (val.sqnorm() < 1e-6f)
         {
             auto bxdf_mat = std::dynamic_pointer_cast<SingleBxdf>(m_base_mat);
-            bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kIdealReflect);
+            if (type == MaterialObject::Type::kMicrofacet)
+                bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kIdealReflect);
+            else if (type == MaterialObject::Type::kMicrofacetRefraction)
+                bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kIdealRefract);
         }
         else
         {
             auto bxdf_mat = std::dynamic_pointer_cast<SingleBxdf>(m_base_mat);
-            bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kMicrofacetGGX);
+            if (type == MaterialObject::Type::kMicrofacet)
+                bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kMicrofacetGGX);
+            else 
+                bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kMicrofacetRefractionGGX);
         }
     }
 }

--- a/Rpr/WrapObject/Materials/SingleBxdfMaterialObject.cpp
+++ b/Rpr/WrapObject/Materials/SingleBxdfMaterialObject.cpp
@@ -96,17 +96,17 @@ void SingleBxdfMaterialObject::SetInputF(const std::string& input_name, const Ra
         if (val.sqnorm() < 1e-6f)
         {
             auto bxdf_mat = std::dynamic_pointer_cast<SingleBxdf>(m_base_mat);
-            if (type == MaterialObject::Type::kMicrofacet)
+            if ((type == MaterialObject::Type::kMicrofacet) || (type == MaterialObject::Type::kReflection))
                 bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kIdealReflect);
-            else if (type == MaterialObject::Type::kMicrofacetRefraction)
+            else if ((type == MaterialObject::Type::kMicrofacetRefraction) || (type == MaterialObject::Type::kRefraction))
                 bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kIdealRefract);
         }
         else
         {
             auto bxdf_mat = std::dynamic_pointer_cast<SingleBxdf>(m_base_mat);
-            if (type == MaterialObject::Type::kMicrofacet)
+            if ((type == MaterialObject::Type::kMicrofacet) || (type == MaterialObject::Type::kReflection))
                 bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kMicrofacetGGX);
-            else 
+            else if ((type == MaterialObject::Type::kMicrofacetRefraction) || (type == MaterialObject::Type::kRefraction))
                 bxdf_mat->SetBxdfType(Baikal::SingleBxdf::BxdfType::kMicrofacetRefractionGGX);
         }
     }

--- a/Rpr/WrapObject/SceneObject.cpp
+++ b/Rpr/WrapObject/SceneObject.cpp
@@ -207,3 +207,57 @@ MaterialObject* SceneObject::GetBackgroundImage() const
 {
     return m_background_image;
 }
+
+void SceneObject::SetEnvironmentOverride(OverrideType overrride, LightObject* light)
+{
+    switch (overrride)
+    {
+    case OverrideType::kBackground:
+        m_environment_override.m_background = light;
+        break;
+    case OverrideType::kReflection:
+        m_environment_override.m_reflection = light;
+        break;
+    case OverrideType::kRefraction:
+        m_environment_override.m_refraction = light;
+        break;
+    case OverrideType::kTransparency:
+        m_environment_override.m_transparency = light;
+        break;
+    }
+
+    m_scene->SetEnvironmentOverride(m_environment_override.ToScene1EnvironmentOverride());
+}
+
+LightObject* SceneObject::GetEnvironmentOverride(OverrideType overrride)
+{
+    switch (overrride)
+    {
+    case OverrideType::kBackground:
+        return m_environment_override.m_background;
+    case OverrideType::kReflection:
+        return m_environment_override.m_reflection;
+    case OverrideType::kRefraction:
+        return m_environment_override.m_refraction;
+    case OverrideType::kTransparency:
+        return m_environment_override.m_transparency;
+    }
+}
+
+Baikal::Scene1::EnvironmentOverride SceneObject::EnvironmentOverride::ToScene1EnvironmentOverride() const
+{
+    Baikal::Scene1::EnvironmentOverride out;
+    out.m_background = m_background ? 
+        std::static_pointer_cast<Baikal::ImageBasedLight>(m_background->GetLight()) : nullptr;
+
+    out.m_reflection = m_reflection ? 
+        std::static_pointer_cast<Baikal::ImageBasedLight>(m_reflection->GetLight()) : nullptr;
+
+    out.m_refraction = m_refraction ? 
+        std::static_pointer_cast<Baikal::ImageBasedLight>(m_refraction->GetLight()) : nullptr;
+
+    out.m_transparency = m_transparency ? 
+        std::static_pointer_cast<Baikal::ImageBasedLight>(m_transparency->GetLight()) : nullptr;
+
+    return out;
+}

--- a/Rpr/WrapObject/SceneObject.cpp
+++ b/Rpr/WrapObject/SceneObject.cpp
@@ -199,8 +199,10 @@ bool SceneObject::IsDirty()
 void SceneObject::SetBackgroundImage(MaterialObject* image)
 {
     m_background_image = image;
-    Baikal::Texture::Ptr texture = m_background_image->GetTexture();
-    m_scene->SetBackgroundImage(texture);
+    if (m_background_image && m_background_image->IsTexture())
+        m_scene->SetBackgroundImage(m_background_image->GetTexture());
+    else
+       m_scene->SetBackgroundImage(nullptr);
 }
 
 MaterialObject* SceneObject::GetBackgroundImage() const

--- a/Rpr/WrapObject/SceneObject.h
+++ b/Rpr/WrapObject/SceneObject.h
@@ -38,6 +38,14 @@ class SceneObject
     : public WrapObject
 {
 public:
+    enum class OverrideType
+    {
+        kReflection,
+        kRefraction,
+        kTransparency,
+        kBackground
+    };
+
     SceneObject();
     virtual ~SceneObject();
 
@@ -63,8 +71,13 @@ public:
 
     RadeonRays::bbox GetBBox();
 
+    // Image override
     void SetBackgroundImage(MaterialObject* image);
     MaterialObject* GetBackgroundImage() const;
+
+    // Environment override
+    void SetEnvironmentOverride(OverrideType overrride, LightObject* light);
+    LightObject* GetEnvironmentOverride(OverrideType overrride);
 
 	void AddEmissive();
 	void RemoveEmissive();
@@ -77,4 +90,13 @@ private:
     std::vector<ShapeObject*> m_shapes;
     std::vector<LightObject*> m_lights;
     MaterialObject *m_background_image;
+
+    struct EnvironmentOverride
+    {
+        LightObject* m_reflection = nullptr;
+        LightObject* m_refraction = nullptr;
+        LightObject* m_transparency = nullptr;
+        LightObject* m_background = nullptr;
+        Baikal::Scene1::EnvironmentOverride ToScene1EnvironmentOverride() const;
+    } m_environment_override;
 };

--- a/RprTest/main.cpp
+++ b/RprTest/main.cpp
@@ -3760,11 +3760,8 @@ void EnvironmentOverrideTest()
     status = rprMaterialNodeSetInputF(refractive, "ior", 2.0f, 2.0f, 2.0f, 1.f);
     assert(status == RPR_SUCCESS);
 
-    rpr_material_node transparent = NULL; status = rprMaterialSystemCreateNode(matsys, /*RPR_MATERIAL_NODE_TRANSPARENT*/
-        RPR_MATERIAL_NODE_PASSTHROUGH, &transparent);
+    rpr_material_node transparent = NULL; status = rprMaterialSystemCreateNode(matsys, RPR_MATERIAL_NODE_PASSTHROUGH, &transparent);
     assert(status == RPR_SUCCESS);
-/*    status = rprMaterialNodeSetInputF(transparent, "color", 1.0f, 1.0f, 1.0f, 1.f);
-    assert(status == RPR_SUCCESS);*/
 
     //sphere
     rpr_shape mesh_reflective = CreateSphere(context, 64, 32, 2.f, float3());
@@ -3810,8 +3807,6 @@ void EnvironmentOverrideTest()
     rpr_image bgImage = NULL;
     status = rprContextCreateImageFromFile(context, "../Resources/Textures/test_albedo1.jpg", &bgImage);
     assert(status == RPR_SUCCESS);
-    /*status = rprSceneSetBackgroundImage(scene, bgImage);
-    assert(status == RPR_SUCCESS);*/
 
     //hdr overrides
     rpr_image hdr_reflection, hdr_refraction, hdr_transparency, hdr_background;
@@ -3892,6 +3887,53 @@ void EnvironmentOverrideTest()
 
     status = rprFrameBufferSaveToFile(frame_buffer, "Output/EnvironmentOverrideTest_pass0.jpg");
     assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND, nullptr);
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_REFLECTION, nullptr);
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetBackgroundImage(scene, bgImage);
+    assert(status == RPR_SUCCESS);
+
+    status = rprFrameBufferClear(frame_buffer);
+    assert(status == RPR_SUCCESS);
+
+    for (int i = 0; i < kRenderIterations; ++i)
+    {
+        status = rprContextRender(context);
+        assert(status == RPR_SUCCESS);
+    }
+
+    status = rprFrameBufferSaveToFile(frame_buffer, "Output/EnvironmentOverrideTest_pass1.jpg");
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_BACKGROUND, light_background);
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_REFLECTION, light_reflection);
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_REFRACTION, nullptr);
+    assert(status == RPR_SUCCESS);
+
+    status = rprSceneSetEnvironmentOverride(scene, RPR_SCENE_ENVIRONMENT_OVERRIDE_TRANSPARENCY, nullptr);
+    assert(status == RPR_SUCCESS);
+
+    status = rprFrameBufferClear(frame_buffer);
+    assert(status == RPR_SUCCESS);
+
+    for (int i = 0; i < kRenderIterations; ++i)
+    {
+        status = rprContextRender(context);
+        assert(status == RPR_SUCCESS);
+    }
+
+    status = rprFrameBufferSaveToFile(frame_buffer, "Output/EnvironmentOverrideTest_pass2.jpg");
+    assert(status == RPR_SUCCESS);
+
+
 
     rpr_render_statistics rs;
     status = rprContextGetInfo(context, RPR_CONTEXT_RENDER_STATISTICS, sizeof(rpr_render_statistics), &rs, NULL);

--- a/RprTest/main.cpp
+++ b/RprTest/main.cpp
@@ -3968,7 +3968,7 @@ void EnvironmentOverrideTest()
 
 int main(int argc, char* argv[])
 {
-    /*MeshCreationTest();
+    MeshCreationTest();
     SimpleRenderTest();
     ComplexRenderTest();
     EnvLightClearTest();
@@ -3988,8 +3988,7 @@ int main(int argc, char* argv[])
     UpdateMaterial();
     ArithmeticMul();
     OrthoRenderTest();
-    BackgroundImageTest();*/
-
+    BackgroundImageTest();
     EnvironmentOverrideTest();
 
     return 0;

--- a/RprTest/main.cpp
+++ b/RprTest/main.cpp
@@ -3760,10 +3760,11 @@ void EnvironmentOverrideTest()
     status = rprMaterialNodeSetInputF(refractive, "ior", 2.0f, 2.0f, 2.0f, 1.f);
     assert(status == RPR_SUCCESS);
 
-    rpr_material_node transparent = NULL; status = rprMaterialSystemCreateNode(matsys, RPR_MATERIAL_NODE_TRANSPARENT, &transparent);
+    rpr_material_node transparent = NULL; status = rprMaterialSystemCreateNode(matsys, /*RPR_MATERIAL_NODE_TRANSPARENT*/
+        RPR_MATERIAL_NODE_PASSTHROUGH, &transparent);
     assert(status == RPR_SUCCESS);
-    status = rprMaterialNodeSetInputF(transparent, "color", 1.0f, 1.0f, 1.0f, 1.f);
-    assert(status == RPR_SUCCESS);
+/*    status = rprMaterialNodeSetInputF(transparent, "color", 1.0f, 1.0f, 1.0f, 1.f);
+    assert(status == RPR_SUCCESS);*/
 
     //sphere
     rpr_shape mesh_reflective = CreateSphere(context, 64, 32, 2.f, float3());


### PR DESCRIPTION
Build tested: Win/OSX/Ubuntu
Baikal test passed on Windows
RPR test works on Windows

- Added 4 environment override options
- Added new kernel ShadeMissWithOverride to handle reflected/refracted and transparancy rays with override
