### PR TITLE
fix the convert from float3 to float4 textures

### DIFF
--- a/Rpr/WrapObject/Materials/ImageMaterialObject.cpp
+++ b/Rpr/WrapObject/Materials/ImageMaterialObject.cpp
@@ -88,7 +88,7 @@ ImageMaterialObject::ImageMaterialObject(rpr_image_format const in_format, rpr_i
             for (unsigned int comp_ind = in_format.num_components; comp_ind < 4; ++comp_ind)
             {
                 int index = comp_ind * component_bytes;
-                memset(&data[i * 4 + index], 0, component_bytes);
+                memset(&data[i * 4 * component_bytes + index], 0, component_bytes);
             }
         }
     }


### PR DESCRIPTION
fix a bug that can be reproduced with  rprContextCreateImage  of a float3 texture.
the convert from float3 to float4 is not correct.