### PR TITLE
Fix Multi GPU Rendering Mode

### DIFF
--- a/Baikal/CMakeLists.txt
+++ b/Baikal/CMakeLists.txt
@@ -2,7 +2,8 @@ set(CONTROLLERS_SOURCES
     Controllers/clw_scene_controller.cpp
     Controllers/clw_scene_controller.h
     Controllers/scene_controller.h
-    Controllers/scene_controller.inl)
+    Controllers/scene_controller.inl
+    Controllers/scene_controller.cpp)
     
 set(ESTIMATORS_SOURCES 
     Estimators/estimator.h

--- a/Baikal/Controllers/scene_controller.cpp
+++ b/Baikal/Controllers/scene_controller.cpp
@@ -1,0 +1,17 @@
+#include <cstdint>
+
+namespace Baikal
+{
+    static std::uint32_t g_next_id = 0;
+
+    std::uint32_t GetNextControllerId()
+    {
+        return g_next_id++;
+    }
+
+    void ResetControllerId()
+    {
+        g_next_id = 0;
+    }
+
+}

--- a/Baikal/Controllers/scene_controller.h
+++ b/Baikal/Controllers/scene_controller.h
@@ -110,6 +110,9 @@ namespace Baikal
         mutable Collector m_texture_collector;
         mutable Collector m_input_maps_collector;
         mutable Collector m_input_map_leafs_collector;
+
+        // Scene controller id
+        std::uint32_t m_id;
     };
 }
 

--- a/Baikal/Controllers/scene_controller.h
+++ b/Baikal/Controllers/scene_controller.h
@@ -62,6 +62,9 @@ namespace Baikal
         CompiledScene& CompileScene(Scene1::Ptr scene) const;
 
         CompiledScene& GetCachedScene(Scene1::Ptr scene) const;
+
+        static void ResetId();
+
     protected:
         // Recompile the scene from scratch, i.e. not loading from cache.
         // All the buffers are recreated and reloaded.

--- a/Baikal/Controllers/scene_controller.inl
+++ b/Baikal/Controllers/scene_controller.inl
@@ -16,13 +16,21 @@
 
 namespace Baikal
 {
-    static std::uint32_t g_next_scene_controller_id = 0;
+    // Defined in scene_controller.cpp
+    std::uint32_t GetNextControllerId();
+    void ResetControllerId();
 
     template <typename CompiledScene>
-    inline
     SceneController<CompiledScene>::SceneController()
-        : m_id(g_next_scene_controller_id++)
-    {}
+        : m_id(GetNextControllerId())
+    {
+    }
+
+    template <typename CompiledScene>
+    void SceneController<CompiledScene>::ResetId()
+    {
+        ResetControllerId();
+    }
 
     template <typename CompiledScene>
     inline

--- a/Baikal/Controllers/scene_controller.inl
+++ b/Baikal/Controllers/scene_controller.inl
@@ -16,9 +16,13 @@
 
 namespace Baikal
 {
+    static std::uint32_t g_next_scene_controller_id = 0;
+
     template <typename CompiledScene>
     inline
-    SceneController<CompiledScene>::SceneController() {}
+    SceneController<CompiledScene>::SceneController()
+        : m_id(g_next_scene_controller_id++)
+    {}
 
     template <typename CompiledScene>
     inline
@@ -38,6 +42,9 @@ namespace Baikal
     CompiledScene& SceneController<CompiledScene>::CompileScene(
         Scene1::Ptr scene
     ) const {
+
+        scene->Acquire(m_id);
+
         // The overall approach is:
         // 1) Check if materials have changed, update collector if yes
         // 2) Check if textures have changed, update collector if yes
@@ -304,6 +311,7 @@ namespace Baikal
             });
 
             // Return the scene
+            scene->Release();
             return res.first->second;
         }
         else
@@ -511,6 +519,7 @@ namespace Baikal
             });
 
             // Return the scene
+            scene->Release();
             return out;
         }
     }

--- a/Baikal/SceneGraph/scene1.cpp
+++ b/Baikal/SceneGraph/scene1.cpp
@@ -7,6 +7,7 @@
 #include <list>
 #include <cassert>
 #include <set>
+#include <mutex>
 
 namespace Baikal
 {
@@ -24,6 +25,7 @@ namespace Baikal
         EnvironmentOverride m_environment_override;
 
         DirtyFlags m_dirty_flags;
+        std::mutex m_scene_mutex;
     };
 
     Scene1::Scene1()
@@ -216,6 +218,18 @@ namespace Baikal
     const Scene1::EnvironmentOverride& Scene1::GetEnvironmentOverride() const
     {
         return m_impl->m_environment_override;
+    }
+
+    void Scene1::Acquire(std::uint32_t controller_id)
+    {
+        m_impl->m_scene_mutex.lock();
+        SceneObject::SetSceneControllerId(controller_id);
+    }
+
+    void Scene1::Release()
+    {
+        SceneObject::ResetSceneControllerId();
+        m_impl->m_scene_mutex.unlock();
     }
 
     namespace {

--- a/Baikal/SceneGraph/scene1.h
+++ b/Baikal/SceneGraph/scene1.h
@@ -126,6 +126,10 @@ namespace Baikal
         // Forbidden stuff
         Scene1(Scene1 const&) = delete;
         Scene1& operator = (Scene1 const&) = delete;
+
+        // Acquire or release scene when scene controller compiles it
+        void Acquire(std::uint32_t controller_id);
+        void Release();
     
     protected:
         // Constructor

--- a/Baikal/SceneGraph/scene_object.cpp
+++ b/Baikal/SceneGraph/scene_object.cpp
@@ -20,7 +20,7 @@ namespace Baikal
         }
         else
         {
-            dirty = (m_dirty & (1 << g_scene_controller_id)) == (1 << g_scene_controller_id);
+            dirty = ((int)m_dirty & (1 << g_scene_controller_id)) == (1 << g_scene_controller_id);
         }
 
         return dirty;

--- a/Baikal/SceneGraph/scene_object.cpp
+++ b/Baikal/SceneGraph/scene_object.cpp
@@ -7,41 +7,30 @@ namespace Baikal
     static int g_scene_controller_id = -1;
 
     SceneObject::SceneObject()
-        : m_dirty(0), m_id(g_next_id++)
+        : m_dirty(), m_id(g_next_id++)
     {
     }
 
     bool SceneObject::IsDirty() const
     {
-        bool dirty = false;
-        if (g_scene_controller_id == -1)
-        {
-            dirty = (m_dirty != 0);
-        }
-        else
-        {
-            dirty = ((int)m_dirty & (1 << g_scene_controller_id)) == (1 << g_scene_controller_id);
-        }
+        assert(g_scene_controller_id >= 0);
 
-        return dirty;
+        return m_dirty[g_scene_controller_id];
+
     }
 
     void SceneObject::SetDirty(bool dirty) const
     {
         if (dirty)
         {
-            m_dirty = 0xFFFFFFFF;
+            // Set all bits to 1
+            m_dirty.set();
         }
         else
         {
-            if (g_scene_controller_id == -1)
-            {
-                m_dirty = 0;
-            }
-            else
-            {
-                m_dirty &= ~(1 << g_scene_controller_id);
-            }
+            assert(g_scene_controller_id >= 0);
+            // Unset corresponging bit
+            m_dirty.set(g_scene_controller_id, false);
         }
     }
 
@@ -52,7 +41,7 @@ namespace Baikal
 
     void SceneObject::SetSceneControllerId(std::uint32_t controller_id)
     {
-        assert(controller_id >= 0 && controller_id < sizeof(std::uint32_t) * 8);
+        assert(controller_id < kMaxDirtyBits);
         g_scene_controller_id = static_cast<int>(controller_id);
     }
 

--- a/Baikal/SceneGraph/scene_object.cpp
+++ b/Baikal/SceneGraph/scene_object.cpp
@@ -1,16 +1,64 @@
 #include "scene_object.h"
+#include <cassert>
 
 namespace Baikal
 {
-    std::uint32_t g_next_id = 0;
+    static std::uint32_t g_next_id = 0;
+    static int g_scene_controller_id = -1;
 
     SceneObject::SceneObject()
-        : m_dirty(false), m_id(g_next_id++)
+        : m_dirty(0), m_id(g_next_id++)
     {
+    }
+
+    bool SceneObject::IsDirty() const
+    {
+        bool dirty = false;
+        if (g_scene_controller_id == -1)
+        {
+            dirty = (m_dirty != 0);
+        }
+        else
+        {
+            dirty = (m_dirty & (1 << g_scene_controller_id)) == (1 << g_scene_controller_id);
+        }
+
+        return dirty;
+    }
+
+    void SceneObject::SetDirty(bool dirty) const
+    {
+        if (dirty)
+        {
+            m_dirty = 0xFFFFFFFF;
+        }
+        else
+        {
+            if (g_scene_controller_id == -1)
+            {
+                m_dirty = 0;
+            }
+            else
+            {
+                m_dirty &= ~(1 << g_scene_controller_id);
+            }
+        }
     }
 
     void SceneObject::ResetId()
     {
         g_next_id = 0;
     }
+
+    void SceneObject::SetSceneControllerId(std::uint32_t controller_id)
+    {
+        assert(controller_id >= 0 && controller_id < sizeof(std::uint32_t) * 8);
+        g_scene_controller_id = static_cast<int>(controller_id);
+    }
+
+    void SceneObject::ResetSceneControllerId()
+    {
+        g_scene_controller_id = -1;
+    }
+
 }

--- a/Baikal/SceneGraph/scene_object.h
+++ b/Baikal/SceneGraph/scene_object.h
@@ -58,13 +58,15 @@ namespace Baikal
         { return m_id; }
 
         static void ResetId();
+        static void SetSceneControllerId(std::uint32_t controller_id);
+        static void ResetSceneControllerId();
 
     protected:
         // Constructor
         SceneObject();
         
     private:
-        mutable bool m_dirty;
+        mutable std::uint32_t m_dirty;
 
         std::string m_name;
         std::uint32_t m_id;
@@ -74,17 +76,7 @@ namespace Baikal
     inline SceneObject::~SceneObject()
     {
     }
-    
-    inline bool SceneObject::IsDirty() const
-    {
-        return m_dirty;
-    }
-    
-    inline void SceneObject::SetDirty(bool dirty) const
-    {
-        m_dirty = dirty;
-    }
-    
+
     inline std::string SceneObject::GetName() const
     {
         return m_name;

--- a/Baikal/SceneGraph/scene_object.h
+++ b/Baikal/SceneGraph/scene_object.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <bitset>
 
 namespace Baikal
 {
@@ -66,7 +67,8 @@ namespace Baikal
         SceneObject();
         
     private:
-        mutable std::uint32_t m_dirty;
+        static const int kMaxDirtyBits = 32;
+        mutable std::bitset<kMaxDirtyBits> m_dirty;
 
         std::string m_name;
         std::uint32_t m_id;

--- a/Baikal/SceneGraph/scene_object.h
+++ b/Baikal/SceneGraph/scene_object.h
@@ -67,6 +67,7 @@ namespace Baikal
         SceneObject();
         
     private:
+        // Bit mask size, equals to bit count of std::uint32_t
         static const int kMaxDirtyBits = 32;
         mutable std::bitset<kMaxDirtyBits> m_dirty;
 

--- a/BaikalStandalone/Application/application.cpp
+++ b/BaikalStandalone/Application/application.cpp
@@ -516,14 +516,12 @@ namespace Baikal
         if (m_settings.num_samples == -1 || m_settings.samplecount <  m_settings.num_samples)
         {
             m_cl->Render(m_settings.samplecount);
-            ++m_settings.samplecount;
+
         }
         else if (m_settings.samplecount == m_settings.num_samples)
         {
             m_cl->SaveFrameBuffer(m_settings);
             std::cout << "Target sample count reached\n";
-            ++m_settings.samplecount;
-            //exit(0);
         }
 
         m_cl->Update(m_settings);
@@ -796,10 +794,16 @@ namespace Baikal
             ImGui::Text("Mouse+RMB to look around");
             ImGui::Text("F1 to hide/show GUI");
             ImGui::Separator();
-            ImGui::Text("Device vendor: %s", m_cl->GetDevice(0).GetVendor().c_str());
-            ImGui::Text("Device name: %s", m_cl->GetDevice(0).GetName().c_str());
-            ImGui::Text("OpenCL: %s", m_cl->GetDevice(0).GetVersion().c_str());
-            ImGui::Separator();
+
+            auto const& configs = m_cl->GetConfigs();
+            for (auto const& cfg : configs)
+            {
+                ImGui::Text("Device vendor: %s", cfg.context.GetDevice(0).GetVendor().c_str());
+                ImGui::Text("Device name: %s", cfg.context.GetDevice(0).GetName().c_str());
+                ImGui::Text("OpenCL: %s", cfg.context.GetDevice(0).GetVersion().c_str());
+                ImGui::Separator();
+            }
+
             ImGui::Text("Resolution: %dx%d ", m_settings.width, m_settings.height);
             ImGui::Text("Scene: %s", m_settings.modelname.c_str());
             ImGui::Text("Unique triangles: %d", m_num_triangles);

--- a/BaikalStandalone/Application/cl_render.cpp
+++ b/BaikalStandalone/Application/cl_render.cpp
@@ -241,6 +241,7 @@ namespace Baikal
     void AppClRender::Update(AppSettings& settings)
     {
         ++settings.samplecount;
+
         for (std::size_t i = 0; i < m_cfgs.size(); ++i)
         {
             if (m_cfgs[i].type == ConfigManager::kPrimary)
@@ -534,6 +535,7 @@ namespace Baikal
         {
             m_renderthreads[i].join();
         }
+
     }
 
     void AppClRender::RunBenchmark(AppSettings& settings)

--- a/BaikalStandalone/Application/cl_render.cpp
+++ b/BaikalStandalone/Application/cl_render.cpp
@@ -127,6 +127,7 @@ namespace Baikal
         for (std::size_t i = 0; i < m_cfgs.size(); ++i)
         {
             m_outputs[i].output = m_cfgs[i].factory->CreateOutput(m_width, m_height);
+            m_outputs[i].dummy_output = m_cfgs[i].factory->CreateOutput(m_width, m_height);
 
 #ifdef ENABLE_DENOISER
             CreateDenoiserOutputs(i, settings.width, settings.height);
@@ -146,10 +147,8 @@ namespace Baikal
         }
 
         m_shape_id_data.output = m_cfgs[m_primary].factory->CreateOutput(m_width, m_height);
-        m_dummy_output_data.output = m_cfgs[m_primary].factory->CreateOutput(m_width, m_height);
         m_cfgs[m_primary].renderer->Clear(RadeonRays::float3(0, 0, 0), *m_outputs[m_primary].output);
         m_cfgs[m_primary].renderer->Clear(RadeonRays::float3(0, 0, 0), *m_shape_id_data.output);
-        m_cfgs[m_primary].renderer->Clear(RadeonRays::float3(0, 0, 0), *m_dummy_output_data.output);
     }
 
 
@@ -605,7 +604,7 @@ namespace Baikal
 #endif
             if (type == Renderer::OutputType::kOpacity || type == Renderer::OutputType::kVisibility)
             {
-                m_cfgs[i].renderer->SetOutput(Renderer::OutputType::kColor, m_dummy_output_data.output.get());
+                m_cfgs[i].renderer->SetOutput(Renderer::OutputType::kColor, m_outputs[i].dummy_output.get());
             }
             else
             {

--- a/BaikalStandalone/Application/cl_render.h
+++ b/BaikalStandalone/Application/cl_render.h
@@ -69,6 +69,7 @@ namespace Baikal
             std::atomic<int> newdata;
             std::mutex datamutex;
             int idx;
+            std::uint32_t scene_state;
         };
 
     public:

--- a/BaikalStandalone/Application/cl_render.h
+++ b/BaikalStandalone/Application/cl_render.h
@@ -47,6 +47,7 @@ namespace Baikal
         struct OutputData
         {
             std::unique_ptr<Baikal::Output> output;
+            std::unique_ptr<Baikal::Output> dummy_output;
 
 #ifdef ENABLE_DENOISER
             std::unique_ptr<Baikal::Output> output_position;
@@ -120,7 +121,6 @@ namespace Baikal
         std::promise<int> m_promise;
         bool m_shape_id_requested = false;
         OutputData m_shape_id_data;
-        OutputData m_dummy_output_data;
         RadeonRays::float2 m_shape_id_pos;
         std::vector<ConfigManager::Config> m_cfgs;
         std::vector<OutputData> m_outputs;

--- a/BaikalStandalone/Application/cl_render.h
+++ b/BaikalStandalone/Application/cl_render.h
@@ -68,9 +68,10 @@ namespace Baikal
             std::atomic<int> clear;
             std::atomic<int> stop;
             std::atomic<int> newdata;
-            std::mutex datamutex;
             int idx;
+            // This is used to reject non-actual data from a worker device
             std::uint32_t scene_state;
+            // Number of samples in the new data that has sent from a worker device
             std::uint32_t new_samples_count;
         };
 

--- a/BaikalStandalone/Application/cl_render.h
+++ b/BaikalStandalone/Application/cl_render.h
@@ -71,6 +71,7 @@ namespace Baikal
             std::mutex datamutex;
             int idx;
             std::uint32_t scene_state;
+            std::uint32_t new_samples_count;
         };
 
     public:
@@ -92,7 +93,7 @@ namespace Baikal
 
         inline Baikal::Camera::Ptr GetCamera() { return m_camera; };
         inline Baikal::Scene1::Ptr GetScene() { return m_scene; };
-        inline CLWDevice GetDevice(int i) { return m_cfgs[m_primary].context.GetDevice(i); };
+        inline const std::vector<ConfigManager::Config>& GetConfigs() const { return m_cfgs; };
         inline Renderer::OutputType GetOutputType() { return m_output_type; };
 
         void SetNumBounces(int num_bounces);

--- a/BaikalStandalone/Utils/config_manager.cpp
+++ b/BaikalStandalone/Utils/config_manager.cpp
@@ -139,11 +139,11 @@ void ConfigManager::CreateConfigs(
                 }
                 catch (CLWException& ex)
                 {
-                    // CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR means that
+                    // CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR (code -1000) means that
                     // CL and GL interop not on the same device.
                     // If we've got another error, throw it up, else simply
                     // continue execution and get to next 'if' block
-                    if (ex.errcode_ != CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR)
+                    if (ex.errcode_ != -1000)
                     {
                         throw;
                     }

--- a/BaikalStandalone/Utils/config_manager.cpp
+++ b/BaikalStandalone/Utils/config_manager.cpp
@@ -94,7 +94,7 @@ void ConfigManager::CreateConfigs(
 
             Config cfg;
             cfg.caninterop = false;
-            bool create_secondary = true;
+            bool create_without_interop = true;
 
             if (platforms[i].GetDevice(d).HasGlInterop() && !hasprimary && interop)
             {
@@ -135,7 +135,7 @@ void ConfigManager::CreateConfigs(
                     cfg.type = kPrimary;
                     cfg.caninterop = true;
                     hasprimary = true;
-                    create_secondary = false;
+                    create_without_interop = false;
                 }
                 catch (CLWException& ex)
                 {
@@ -150,8 +150,8 @@ void ConfigManager::CreateConfigs(
 
                 }
             }
-            
-            if (create_secondary)
+
+            if (create_without_interop)
             {
                 cfg.context = CLWContext::Create(platforms[i].GetDevice(d));
                 cfg.type = kSecondary;

--- a/BaikalStandalone/Utils/config_manager.cpp
+++ b/BaikalStandalone/Utils/config_manager.cpp
@@ -94,6 +94,7 @@ void ConfigManager::CreateConfigs(
 
             Config cfg;
             cfg.caninterop = false;
+            bool create_secondary = true;
 
             if (platforms[i].GetDevice(d).HasGlInterop() && !hasprimary && interop)
             {
@@ -128,12 +129,29 @@ void ConfigManager::CreateConfigs(
                     (cl_context_properties)kCGLShareGroup, 0
                 };
 #endif
-                cfg.context = CLWContext::Create(platforms[i].GetDevice(d), props);
-                cfg.type = kPrimary;
-                cfg.caninterop = true;
-                hasprimary = true;
+                try
+                {
+                    cfg.context = CLWContext::Create(platforms[i].GetDevice(d), props);
+                    cfg.type = kPrimary;
+                    cfg.caninterop = true;
+                    hasprimary = true;
+                    create_secondary = false;
+                }
+                catch (CLWException& ex)
+                {
+                    // CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR means that
+                    // CL and GL interop not on the same device.
+                    // If we've got another error, throw it up, else simply
+                    // continue execution and get to next 'if' block
+                    if (ex.errcode_ != CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR)
+                    {
+                        throw;
+                    }
+
+                }
             }
-            else
+            
+            if (create_secondary)
             {
                 cfg.context = CLWContext::Create(platforms[i].GetDevice(d));
                 cfg.type = kSecondary;

--- a/BaikalTest/basic.h
+++ b/BaikalTest/basic.h
@@ -74,6 +74,7 @@ public:
         m_output_path.append("/");
 
         Baikal::SceneObject::ResetId();
+        Baikal::SceneController<Baikal::ClwScene>::ResetId();
 
         // Prefer GPU devices if nothing has been specified
         if (platform_index == -1)

--- a/RprTest/basic.h
+++ b/RprTest/basic.h
@@ -32,6 +32,8 @@
 #include "gtest/gtest.h"
 #include "OpenImageIO/imageio.h"
 #include "SceneGraph/scene_object.h"
+#include "Controllers/scene_controller.h"
+#include "SceneGraph/clwscene.h"
 
 #include <vector>
 #include <memory>
@@ -74,8 +76,8 @@ public:
         m_reference_path.append("/");
         m_output_path.append("/");
 
-
         Baikal::SceneObject::ResetId();
+        Baikal::SceneController<Baikal::ClwScene>::ResetId();
 
         rpr_creation_flags flags = GetCreationFlags();
         ASSERT_EQ(rprCreateContext(RPR_API_VERSION, nullptr, 0, flags, nullptr, nullptr, &m_context), RPR_SUCCESS);


### PR DESCRIPTION
- Fix data race when one thread used to drop dirty flags and the others didn't recompile the scene;
- Fix data race when a slower thread sent non-actual information after scene update;
- Fix crash with mgpu config and enabled denoiser;
- Add showing all devices in the gui and add accounting samples from worker threads.