### PR TITLE
Be able to share compiled OpenCL binary caches among identical GPUs

### DIFF
--- a/Baikal/Controllers/clw_scene_controller.cpp
+++ b/Baikal/Controllers/clw_scene_controller.cpp
@@ -51,10 +51,11 @@ namespace Baikal
     }
 
 
+    Material::Ptr ClwSceneController::s_default_material = UberV2Material::Create();
+
     ClwSceneController::ClwSceneController(CLWContext context, RadeonRays::IntersectionApi* api, const CLProgramManager *program_manager)
     : m_context(context)
     , m_api(api)
-    , m_default_material(UberV2Material::Create())
     , m_program_manager(program_manager)
     {
         auto acc_type = "fatbvh";
@@ -72,7 +73,7 @@ namespace Baikal
 
     Material::Ptr ClwSceneController::GetDefaultMaterial() const
     {
-        return m_default_material;
+        return s_default_material;
     }
 
     ClwSceneController::~ClwSceneController()
@@ -1275,7 +1276,7 @@ namespace Baikal
 
     int ClwSceneController::GetMaterialIndex(Collector const& collector, Material::Ptr material) const
     {
-        auto m = material ? material : m_default_material;
+        auto m = material ? material : s_default_material;
         return ResolveMaterialPtr(m);
     }
 
@@ -1392,7 +1393,7 @@ namespace Baikal
 
     int ClwSceneController::GetMaterialLayers(Material::Ptr material) const
     {
-        auto m = material ? material : m_default_material;
+        auto m = material ? material : s_default_material;
         return std::static_pointer_cast<UberV2Material>(m)->GetLayers();
     }
 

--- a/Baikal/Controllers/clw_scene_controller.h
+++ b/Baikal/Controllers/clw_scene_controller.h
@@ -129,7 +129,7 @@ namespace Baikal
         // Intersection API
         RadeonRays::IntersectionApi* m_api;
         // Default material
-        Material::Ptr m_default_material;
+        static Material::Ptr s_default_material;
         // CL Program manager
         const CLProgramManager *m_program_manager;
         // Material to device material map

--- a/Baikal/Utils/cl_program.h
+++ b/Baikal/Utils/cl_program.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <mutex>
 #include "CLWProgram.h"
 #include "CLWContext.h"
 
@@ -95,5 +96,7 @@ namespace Baikal
         CLWContext m_context;
         std::set<std::string> m_included_headers; ///< Set of included headers
 
+        static std::unordered_map<std::string, std::shared_ptr<std::mutex>> s_binary_cache_names;
+        static std::mutex s_binary_cache_map_mutex;
     };
 }


### PR DESCRIPTION
This change solved the following issue
1. When rendering with multiple GPUs/CPUs, the generated inputmap.cl of worker threads are different to each other
Because each worker thread use its own instance of default_material in ClwSceneController, which has its own SceneObject id
Different SceneObject id means different inputmap id, lead to different inputmap.cl

Change default_material from member variable to static variable solve this issue

2. If rendering with multiple identical GPUs, they should have share the same kernel binary caches (with the first issue solved)
But if there is no cache exists, all the GPUs will try to compile and generate the very same binary cache, at the same time
This may cause a huge spike in memory consumption with lots of wasted works

Added a lock mechanism to allow only one worker to compile and generate binary cache, while the others will simply wait for it
Any workers with different GPU/CPU model won't be affected and will be able to generate their own version of kernel binaries